### PR TITLE
expect() implementation and addition of waveguide operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WaveguideQED"
 uuid = "c4555495-0e8d-488d-8e6a-965ecefe9055"
 authors = ["Matias Bundgaard-Nielsen <mabuni1998@gmail.com>, Mikkel Heuck <mheu@dtu.dk>, and Stefan Krastanov <stefankr@mit.edu>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/WaveguideInteraction.jl
+++ b/src/WaveguideInteraction.jl
@@ -299,7 +299,7 @@ function waveguide_interaction_mul!(result,a::WaveguideDestroy{B1,B2,Np,idx1},bo
 end
 
 
-function Base.:*(a::WaveguideCreate{B1,B2,Np,idx1},b::WaveguideDestroy{B1,B2,Np,idx2}) where {B1,B2,Np,idx1,idx2}
+function Base.:*(a::O1,b::O2) where {O1 <: WaveguideOperator,O2 <: WaveguideOperator}
     WaveguideInteraction(basis(a),basis(a),complex(1.0),a,b,1)
 end
 function Base.:*(a::T1,b::T2) where {T1<: WaveguideOperatorT,T2<: WaveguideOperatorT}
@@ -307,16 +307,37 @@ function Base.:*(a::T1,b::T2) where {T1<: WaveguideOperatorT,T2<: WaveguideOpera
     WaveguideInteraction(basis(a),basis(a),a.factor*b.factor,a.operators[1],b.operators[1],a.indices[1])
 end
 
-const TensorWaveguideInteraction = LazyTensor{B,B,F,V,T} where {B,F,V,T<:Tuple{WaveguideInteraction}}
+const TensorWaveguideInteraction = LazyTensor{B,B,F,V,T} where {B,F,V,T<:Tuple{Vararg{Union{WaveguideInteraction,WaveguideOperator,CavityWaveguideOperator}}}}
+const WaveguideSum = LazySum{B,B,F,T} where {B,F,T<:Tuple{Vararg{Union{WaveguideInteraction,WaveguideOperator,CavityWaveguideOperator}}}}
 
+function zerophoton_projector(psi::Ket)
+    zerophoton_projector(basis(psi))
+end
 
-function expect(a::T,psi::Ket) where T<:Union{WaveguideInteraction,TensorWaveguideInteraction}
+function zerophoton_projector(basis::WaveguideBasis)
+    dm(zerophoton(basis))
+end
+
+function zerophoton_projector(basis::Basis)
+    identityoperator(basis)
+end
+
+function zerophoton_projector(b::CompositeBasis)
+    tensor([zerophoton_projector(b.bases[i]) for i in 1:length(b.bases)]...)
+end
+
+function expect(a::T,psi::Ket) where T<:Union{WaveguideOperator,WaveguideInteraction,TensorWaveguideInteraction,WaveguideSum,CavityWaveguideOperator}
     out = 0
     tmp_ket = Ket(psi.basis)
-    for i in 1:get_nsteps(basis(a))
+    projector = zerophoton_projector(psi)
+    set_waveguidetimeindex!(a,1)
+    mul!(tmp_ket,a,psi,1,0)
+    zero_part = expect(projector,tmp_ket)
+    out += dot(psi.data,tmp_ket.data)
+    for i in 2:get_nsteps(basis(a))
         set_waveguidetimeindex!(a,i)
         mul!(tmp_ket,a,psi,1,0)
-        out += dot(psi.data,tmp_ket.data)
+        out += (dot(psi.data,tmp_ket.data) - zero_part)
     end
     out
 end

--- a/src/WaveguideOperator.jl
+++ b/src/WaveguideOperator.jl
@@ -64,6 +64,13 @@ function Base.:/(a::WaveguideOperator,b::Number)
 end
 Base.:-(a::WaveguideOperator) = *(-1,a)
 
+Base.:+(a::WaveguideOperator{B1,B2},b::WaveguideOperator{B1,B2}) where {B1,B2} = LazySum(a) + LazySum(b)
+Base.:-(a::WaveguideOperator{B1,B2},b::WaveguideOperator{B1,B2}) where {B1,B2} = LazySum(a) - LazySum(b)
+Base.:+(a::WaveguideOperator{B1,B2},b::LazySum{B1,B2}) where {B1,B2} = LazySum(a) + LazySum(b)
+Base.:+(a::LazySum{B1,B2},b::WaveguideOperator{B1,B2}) where {B1,B2} = LazySum(a) + LazySum(b)
+Base.:-(a::WaveguideOperator{B1,B2},b::LazySum{B1,B2}) where {B1,B2}= LazySum(a) - LazySum(b)
+Base.:-(a::LazySum{B1,B2},b::WaveguideOperator{B1,B2}) where {B1,B2}= LazySum(a) - LazySum(b)
+
 """
     destroy(basis::WaveguideBasis{Np,1}) where {Np}
     destroy(basis::WaveguideBasis{Np,Nw},i::Int) where {Np,Nw}

--- a/test/test_singlecavity.jl
+++ b/test/test_singlecavity.jl
@@ -22,7 +22,7 @@ include("helper_functions.jl")
     wd = create(bw);
     wda = a ⊗ wd
     adw = ad ⊗ w
-    H = param.δ*n + im*sqrt(param.γ/dt)*(adw-wda) + param.x3/4*(n*n+n)
+    H = param.δ*n + im*sqrt(param.γ/dt)*(adw-wda)
     #Define input twophoton state shape
     ξfun(t,σ,t0) = complex( sqrt(2/σ)* (log(2)/pi)^(1/4)*exp(-2*log(2)*(t-t0)^2/σ^2))
     ξvec = ξfun.(param.times,param.σ,param.t0)


### PR DESCRIPTION
expect(O,rho), with O being related to a waveguideoperator, now returns a sum over all time bins.

Also added the ability to add two waveguide operators by creating a lazysum: 
```
w = destroy(bw)
wd = create(bw)
S = w + wd
```

See also: https://github.com/qojulia/WaveguideQED.jl/issues/44